### PR TITLE
Add rule `react/no-array-index-key`

### DIFF
--- a/lib/recommended.js
+++ b/lib/recommended.js
@@ -88,6 +88,7 @@ module.exports = {
         "react/self-closing-comp": ["error"],
         "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
         "react/jsx-key": ["error"],
+        "react/no-array-index-key": ["error"],
         "react/jsx-sort-props": [
             "error",
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eslint-config-crema",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eslint-config-crema",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "@rushstack/eslint-patch": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "name": "Crema",
         "url": "https://crema.us/"
     },
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A batteries-included ESLint config by Crema for Cremanians and you.",
     "keywords": [
         "eslint",

--- a/tests/eslint-config-crema.test.ts
+++ b/tests/eslint-config-crema.test.ts
@@ -47,4 +47,39 @@ describe("eslint-config-crema recommended config", () => {
             doSomething();
         `)
     })
+
+    it("should disallow index as keys", async () => {
+        const incorrectCode = `
+            function Hello() {
+                return <div>Hello</div>;
+            }
+
+            const things = [{ id: 1 }, { id: 2 }];
+            things.map((thing, index) => (
+                <Hello key={index} />
+            ));
+        `
+
+        const result = await plugin.lintText(incorrectCode, {
+            filePath: "test.js",
+        })
+        expect(result[0].errorCount).toBe(1)
+
+        const correctCode = `
+            function Hello() {
+                return <div>Hello</div>;
+            }
+
+            const things = [{ id: 1 }, { id: 2 }];
+            things.map((thing) => (
+                <Hello key={thing.id} />
+            ));
+        `
+
+        const result2 = await plugin.lintText(correctCode, {
+            filePath: "test.js",
+        })
+
+        expect(result2[0].errorCount).toBe(0)
+    })
 })


### PR DESCRIPTION
https://react.dev/learn/rendering-lists#why-does-react-need-keys

> You might be tempted to use an item’s index in the array as its key. In fact, that’s what React will use if you don’t specify a key at all. But the order in which you render items will change over time if an item is inserted, deleted, or if the array gets reordered. Index as a key often leads to subtle and confusing bugs.